### PR TITLE
RCT-326 add toast stating success/failure of form submission

### DIFF
--- a/views.py
+++ b/views.py
@@ -1,5 +1,6 @@
 from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render
+from django.contrib import messages
 
 from plugins.editorial_manager_transfer_service import forms
 from plugins.editorial_manager_transfer_service.logic import get_plugin_settings, save_plugin_settings
@@ -32,6 +33,18 @@ def manager(request):
                 license_code,
                 journal_code,
                 request,
+            )
+
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                'Form saved.',
+            )
+        else:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                'Error saving form.',
             )
 
     else:


### PR DESCRIPTION
https://plos.atlassian.net/browse/RCT-326

populates the messages field upon form submission in order to display a success/failure toast

<img width="1165" height="663" alt="Screenshot 2025-09-16 at 3 32 21 PM" src="https://github.com/user-attachments/assets/0186289f-1322-4143-8ae1-b5063dddc4c6" />
